### PR TITLE
Implement usability and storytelling enhancements

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ class IBSApp {
             equipment: '',
             severity: '',
             status: '',
-            period: 90
+            period: 90,
+            search: ''
         };
         this.currentIncidentId = null;
         this.comments = {};
@@ -91,6 +92,8 @@ class IBSApp {
         setTimeout(() => {
             this.createCharts();
         }, 100);
+
+        this.setupThemeToggle();
     }
 
     generateMockData() {
@@ -317,6 +320,11 @@ class IBSApp {
             this.applyFilters();
         });
 
+        document.getElementById('searchInput').addEventListener('keyup', (e) => {
+            this.filters.search = e.target.value;
+            this.applyFilters();
+        });
+
         document.getElementById('clearFilters').addEventListener('click', () => {
             this.clearFilters();
         });
@@ -465,13 +473,18 @@ class IBSApp {
         const now = new Date();
         const periodStart = new Date(now.getTime() - (this.filters.period * 24 * 60 * 60 * 1000));
 
+        const search = this.filters.search.toLowerCase();
         this.filteredIncidents = this.incidents.filter(incident => {
             const matchesPeriod = incident.startDate >= periodStart;
             const matchesEquipment = !this.filters.equipment || incident.equipment === this.filters.equipment;
             const matchesSeverity = !this.filters.severity || incident.severity === this.filters.severity;
             const matchesStatus = !this.filters.status || incident.status === this.filters.status;
+            const matchesSearch = !search ||
+                incident.id.toLowerCase().includes(search) ||
+                incident.description.toLowerCase().includes(search) ||
+                incident.agency.toLowerCase().includes(search);
 
-            return matchesPeriod && matchesEquipment && matchesSeverity && matchesStatus;
+            return matchesPeriod && matchesEquipment && matchesSeverity && matchesStatus && matchesSearch;
         });
 
         this.currentPage = 1;
@@ -485,13 +498,15 @@ class IBSApp {
             equipment: '',
             severity: '',
             status: '',
-            period: 90
+            period: 90,
+            search: ''
         };
 
         document.getElementById('equipmentFilter').value = '';
         document.getElementById('severityFilter').value = '';
         document.getElementById('statusFilter').value = '';
         document.getElementById('periodFilter').value = '90';
+        document.getElementById('searchInput').value = '';
 
         this.applyFilters();
     }
@@ -519,6 +534,9 @@ class IBSApp {
         document.getElementById('activePercentage').textContent = total > 0 ? `${Math.round((active / total) * 100)}% do total` : '0% do total';
         document.getElementById('averageMTTR').textContent = `${avgMTTR.toFixed(1)}h`;
         document.getElementById('averageMTTD').textContent = `${(avgMTTD * 60).toFixed(0)}min`;
+
+        const summary = `Nos últimos ${this.filters.period} dias foram registradas ${total} ocorrências, ${resolved} resolvidas.`;
+        document.getElementById('summaryText').textContent = summary;
     }
 
     createCharts() {
@@ -976,6 +994,8 @@ class IBSApp {
             </div>
         `;
 
+        this.renderTimeline(incidentId);
+
         // Reset to details tab
         this.switchTab('details');
         document.getElementById('incidentModal').classList.remove('hidden');
@@ -1094,11 +1114,39 @@ class IBSApp {
                     </span>
                 </div>
                 <div class="communication-meta">
-                    <strong>Para:</strong> ${comm.supplier} • 
-                    <strong>Prioridade:</strong> ${comm.priority.charAt(0).toUpperCase() + comm.priority.slice(1)} • 
+                    <strong>Para:</strong> ${comm.supplier} •
+                    <strong>Prioridade:</strong> ${comm.priority.charAt(0).toUpperCase() + comm.priority.slice(1)} •
                     ${comm.timestamp.toLocaleDateString('pt-BR')} ${comm.timestamp.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
                 </div>
                 <div class="communication-text">${comm.message}</div>
+            </div>
+        `).join('');
+    }
+
+    renderTimeline(incidentId) {
+        const container = document.getElementById('timelineContainer');
+        if (!container) return;
+        const incident = this.incidents.find(inc => inc.id === incidentId);
+        if (!incident) return;
+
+        const events = [];
+        events.push({ time: incident.startDate, text: 'Incidente aberto' });
+        (this.comments[incidentId] || []).forEach(c => {
+            events.push({ time: c.timestamp, text: `Comentário: ${c.text}` });
+        });
+        (this.communications[incidentId] || []).forEach(c => {
+            events.push({ time: c.timestamp, text: `Comunicação: ${c.subject}` });
+        });
+        if (incident.resolutionDate) {
+            events.push({ time: incident.resolutionDate, text: 'Incidente resolvido' });
+        }
+
+        events.sort((a, b) => a.time - b.time);
+
+        container.innerHTML = events.map(ev => `
+            <div class="timeline-item">
+                <div class="timeline-date">${ev.time.toLocaleDateString('pt-BR')} ${ev.time.toLocaleTimeString('pt-BR')}</div>
+                <div class="timeline-text">${ev.text}</div>
             </div>
         `).join('');
     }
@@ -1252,17 +1300,46 @@ class IBSApp {
         }, 300);
     }
 
+    setupThemeToggle() {
+        const body = document.body;
+        const saved = localStorage.getItem('theme');
+        if (saved) {
+            body.dataset.colorScheme = saved;
+        }
+        const btn = document.getElementById('themeToggle');
+        if (btn) {
+            btn.addEventListener('click', () => {
+                const next = body.dataset.colorScheme === 'dark' ? 'light' : 'dark';
+                body.dataset.colorScheme = next;
+                localStorage.setItem('theme', next);
+            });
+        }
+    }
+
     exportData() {
-        const csvContent = this.generateCSV();
-        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-        const link = document.createElement('a');
-        const url = URL.createObjectURL(blob);
-        link.setAttribute('href', url);
-        link.setAttribute('download', `incidentes_itau_${new Date().toISOString().split('T')[0]}.csv`);
-        link.style.visibility = 'hidden';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        const btn = document.getElementById('exportBtn');
+        if (btn) {
+            btn.classList.add('loading');
+            btn.textContent = 'Exportando...';
+        }
+
+        setTimeout(() => {
+            const csvContent = this.generateCSV();
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const link = document.createElement('a');
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', `incidentes_itau_${new Date().toISOString().split('T')[0]}.csv`);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+            if (btn) {
+                btn.classList.remove('loading');
+                btn.textContent = 'Exportar Relatório';
+            }
+        }, 500);
     }
 
     generateCSV() {

--- a/index.html
+++ b/index.html
@@ -12,13 +12,14 @@
     <header class="header">
         <div class="header-content">
             <div class="header-left">
-                <div class="logo">
-                    <span class="logo-icon">🏦</span>
+                <div class="logo" aria-label="Itaú">
+                    <span class="logo-icon" aria-hidden="true">🏦</span>
                     <span class="logo-text">Ferramenta de Acompanhamento - COPF</span>
                 </div>
             </div>
             <div class="header-right">
                 <span class="user-info">Sistema Itaú - Gestão de Ocorrências</span>
+                <button id="themeToggle" class="btn btn--secondary" aria-label="Alternar tema">🌓</button>
             </div>
         </div>
     </header>
@@ -29,26 +30,26 @@
             <nav class="sidebar-nav">
                 <ul class="nav-list">
                     <li class="nav-item active">
-                        <a href="#" class="nav-link" data-section="dashboard">
-                            <span class="nav-icon">📊</span>
+                        <a href="#" class="nav-link" data-section="dashboard" aria-label="Dashboard">
+                            <span class="nav-icon" aria-hidden="true">📊</span>
                             <span class="nav-text">Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="incidents">
-                            <span class="nav-icon">⚠️</span>
+                        <a href="#" class="nav-link" data-section="incidents" aria-label="Ocorrências">
+                            <span class="nav-icon" aria-hidden="true">⚠️</span>
                             <span class="nav-text">Ocorrências</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="reports">
-                            <span class="nav-icon">📈</span>
+                        <a href="#" class="nav-link" data-section="reports" aria-label="Relatórios">
+                            <span class="nav-icon" aria-hidden="true">📈</span>
                             <span class="nav-text">Relatórios</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="settings">
-                            <span class="nav-icon">⚙️</span>
+                        <a href="#" class="nav-link" data-section="settings" aria-label="Configurações">
+                            <span class="nav-icon" aria-hidden="true">⚙️</span>
                             <span class="nav-text">Configurações</span>
                         </a>
                     </li>
@@ -86,6 +87,10 @@
                             <option value="60">Últimos 60 dias</option>
                             <option value="90" selected>Últimos 90 dias</option>
                         </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="searchInput" class="form-label">Busca Rápida:</label>
+                        <input id="searchInput" type="text" class="form-control" placeholder="Buscar por texto ou ID">
                     </div>
                     <div class="filter-group">
                         <button id="clearFilters" class="btn btn--secondary">Limpar Filtros</button>
@@ -138,6 +143,8 @@
                         <div class="kpi-subtitle">Tempo médio de detecção</div>
                     </div>
                 </div>
+
+                <p id="summaryText" class="summary-text"></p>
 
                 <!-- Charts Grid -->
                 <div class="charts-grid">
@@ -222,7 +229,7 @@
         <div class="modal-content modal-content--large">
             <div class="modal-header">
                 <h3 class="modal-title">Detalhes do Incidente</h3>
-                <button class="modal-close" id="closeModal">&times;</button>
+                <button class="modal-close" id="closeModal" aria-label="Fechar">&times;</button>
             </div>
             <div class="modal-tabs">
                 <button class="tab-button active" data-tab="details">Detalhes</button>
@@ -232,6 +239,7 @@
             <div class="modal-body">
                 <div class="tab-content active" id="tab-details">
                     <div id="modalBody"></div>
+                    <div id="timelineContainer" class="timeline-list"></div>
                 </div>
                 <div class="tab-content" id="tab-comments">
                     <div class="comments-section">
@@ -250,7 +258,7 @@
                             </div>
                             <div class="comment-actions">
                                 <button class="btn btn--secondary" id="saveComment">Salvar Comentário</button>
-                                <button class="btn btn--primary" id="sendToSupplier">Enviar para Fornecedor</button>
+                                <button class="btn btn--primary" id="sendToSupplier" aria-label="Enviar para Fornecedor">Enviar para Fornecedor</button>
                             </div>
                         </div>
                         <div class="comments-history">
@@ -262,7 +270,7 @@
                 <div class="tab-content" id="tab-communications">
                     <div class="communications-section">
                         <div class="communication-actions">
-                            <button class="btn btn--primary" id="newCommunication">📤 Nova Comunicação</button>
+                            <button class="btn btn--primary" id="newCommunication" aria-label="Nova Comunicação">📤 Nova Comunicação</button>
                         </div>
                         <div class="communications-history">
                             <h4>Histórico de Comunicações</h4>
@@ -279,7 +287,7 @@
         <div class="modal-content modal-content--large">
             <div class="modal-header">
                 <h3 class="modal-title">💬 Comunicação com Fornecedor</h3>
-                <button class="modal-close" id="closeSupplierModal">&times;</button>
+                <button class="modal-close" id="closeSupplierModal" aria-label="Fechar">&times;</button>
             </div>
             <div class="modal-body">
                 <div class="supplier-form">
@@ -342,7 +350,7 @@
 
                     <div class="supplier-actions">
                         <button class="btn btn--secondary" id="cancelCommunication">Cancelar</button>
-                        <button class="btn btn--primary" id="sendCommunication">📤 Enviar para Fornecedor</button>
+                        <button class="btn btn--primary" id="sendCommunication" aria-label="Enviar para Fornecedor">📤 Enviar para Fornecedor</button>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -2363,3 +2363,38 @@ select.form-control {
   background: linear-gradient(to left, var(--color-surface), transparent);
   pointer-events: none;
 }
+
+/* Summary text below KPIs */
+.summary-text {
+  margin: var(--space-16) 0;
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+}
+
+/* Simple timeline */
+.timeline-list {
+  margin-top: var(--space-16);
+  padding-left: var(--space-16);
+  border-left: 2px solid var(--color-border);
+}
+
+.timeline-item {
+  margin-bottom: var(--space-12);
+  position: relative;
+}
+
+.timeline-item::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  position: absolute;
+  left: -5px;
+  top: 4px;
+}
+
+.timeline-date {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}


### PR DESCRIPTION
## Summary
- add theme toggle button in header
- include quick search filter
- show summary text for KPI section
- introduce timeline in incident modal
- add accessible aria labels
- implement theme persistence and search filtering in JS
- show loading state for CSV export

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6867f755ee7c83289fd9176a05d64e69