### PR TITLE
Implement usability and storytelling enhancements

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,6 +87,30 @@ class IBSApp {
             "5002 - Aldeota": [-3.7363, -38.4885]
         };
 
+        this.agencyInfo = {
+            "1001 - Vila Olímpia": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Próprio", tipo: "Full Service", arquetipo: "Standard" },
+            "1002 - Faria Lima": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: true, imovel: "Alugado", tipo: "Full Service", arquetipo: "Premium" },
+            "1003 - Paulista": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Próprio", tipo: "Espaço Itaú", arquetipo: "Premium" },
+            "1004 - Moema": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Alugado", tipo: "Full Service", arquetipo: "Standard" },
+            "1005 - Itaim Bibi": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: true, imovel: "Próprio", tipo: "Full Service", arquetipo: "Premium" },
+            "1006 - Brooklin": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Alugado", tipo: "Espaço Itaú", arquetipo: "Standard" },
+            "1007 - Santo Amaro": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Próprio", tipo: "Full Service", arquetipo: "UltraLight" },
+            "1008 - Pinheiros": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: true, imovel: "Alugado", tipo: "Full Service", arquetipo: "Premium" },
+            "1009 - Vila Madalena": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Próprio", tipo: "Espaço Itaú", arquetipo: "UltraLight" },
+            "1010 - Perdizes": { municipio: "São Paulo", diretoria: "Diretoria SP", vip: false, imovel: "Alugado", tipo: "Full Service", arquetipo: "Standard" },
+            "2001 - Copacabana": { municipio: "Rio de Janeiro", diretoria: "Diretoria RJ", vip: true, imovel: "Próprio", tipo: "Full Service", arquetipo: "Premium" },
+            "2002 - Ipanema": { municipio: "Rio de Janeiro", diretoria: "Diretoria RJ", vip: true, imovel: "Alugado", tipo: "Espaço Itaú", arquetipo: "Premium" },
+            "2003 - Leblon": { municipio: "Rio de Janeiro", diretoria: "Diretoria RJ", vip: true, imovel: "Próprio", tipo: "Full Service", arquetipo: "Premium" },
+            "2004 - Barra da Tijuca": { municipio: "Rio de Janeiro", diretoria: "Diretoria RJ", vip: false, imovel: "Alugado", tipo: "Full Service", arquetipo: "Standard" },
+            "2005 - Tijuca": { municipio: "Rio de Janeiro", diretoria: "Diretoria RJ", vip: false, imovel: "Próprio", tipo: "Espaço Itaú", arquetipo: "Standard" },
+            "3001 - Savassi BH": { municipio: "Belo Horizonte", diretoria: "Diretoria MG", vip: false, imovel: "Próprio", tipo: "Full Service", arquetipo: "Standard" },
+            "3002 - Centro BH": { municipio: "Belo Horizonte", diretoria: "Diretoria MG", vip: false, imovel: "Alugado", tipo: "Espaço Itaú", arquetipo: "Standard" },
+            "4001 - Boa Viagem": { municipio: "Recife", diretoria: "Diretoria PE", vip: true, imovel: "Próprio", tipo: "Full Service", arquetipo: "Premium" },
+            "4002 - Casa Forte": { municipio: "Recife", diretoria: "Diretoria PE", vip: false, imovel: "Alugado", tipo: "Espaço Itaú", arquetipo: "Standard" },
+            "5001 - Meireles": { municipio: "Fortaleza", diretoria: "Diretoria CE", vip: false, imovel: "Próprio", tipo: "Full Service", arquetipo: "Standard" },
+            "5002 - Aldeota": { municipio: "Fortaleza", diretoria: "Diretoria CE", vip: false, imovel: "Alugado", tipo: "Espaço Itaú", arquetipo: "UltraLight" }
+        };
+
         this.responsaveis = [
             "João Silva - Técnico TI", "Maria Santos - Suporte N2", "Pedro Costa - Especialista ATM",
             "Ana Oliveira - Técnico Redes", "Carlos Lima - Suporte Segurança", "Fernanda Alves - Técnico Hardware",
@@ -395,6 +419,10 @@ class IBSApp {
             document.getElementById('supplierModal').classList.add('hidden');
         });
 
+        document.getElementById('closeAgencyModal').addEventListener('click', () => {
+            document.getElementById('agencyModal').classList.add('hidden');
+        });
+
         // Click outside modal to close
         document.getElementById('incidentModal').addEventListener('click', (e) => {
             if (e.target.id === 'incidentModal') {
@@ -405,6 +433,12 @@ class IBSApp {
         document.getElementById('supplierModal').addEventListener('click', (e) => {
             if (e.target.id === 'supplierModal') {
                 document.getElementById('supplierModal').classList.add('hidden');
+            }
+        });
+
+        document.getElementById('agencyModal').addEventListener('click', (e) => {
+            if (e.target.id === 'agencyModal') {
+                document.getElementById('agencyModal').classList.add('hidden');
             }
         });
 
@@ -1230,7 +1264,7 @@ class IBSApp {
                     <span class="equipment-icon">${incident.equipmentIcon}</span>
                     ${incident.equipment}
                 </td>
-                <td>${incident.agency}</td>
+                <td><button class="agency-link" data-agency="${incident.agency}">${incident.agency}</button></td>
                 <td>
                     <span class="severity-badge severity-${severityClass}">${incident.severity}</span>
                 </td>
@@ -1253,9 +1287,11 @@ class IBSApp {
             // Add event listeners to the buttons
             const viewBtn = row.querySelector('.btn-view');
             const commBtn = row.querySelector('.btn-communicate');
-            
+            const agencyBtn = row.querySelector('.agency-link');
+
             viewBtn.addEventListener('click', () => this.showIncidentDetail(incident.id));
             commBtn.addEventListener('click', () => this.openSupplierCommunication(incident.id));
+            agencyBtn.addEventListener('click', () => this.showAgencyInfo(incident.agency));
             
             tableBody.appendChild(row);
         });
@@ -1405,6 +1441,22 @@ class IBSApp {
         // Reset to details tab
         this.switchTab('details');
         document.getElementById('incidentModal').classList.remove('hidden');
+    }
+
+    showAgencyInfo(agency) {
+        const info = this.agencyInfo[agency];
+        if (!info) return;
+        const body = document.getElementById('agencyModalBody');
+        body.innerHTML = `
+            <div class="detail-row"><span class="detail-label">Agência:</span><span class="detail-value">${agency}</span></div>
+            <div class="detail-row"><span class="detail-label">Município:</span><span class="detail-value">${info.municipio}</span></div>
+            <div class="detail-row"><span class="detail-label">Diretoria Comercial:</span><span class="detail-value">${info.diretoria}</span></div>
+            <div class="detail-row"><span class="detail-label">VIP:</span><span class="detail-value">${info.vip ? 'Sim' : 'Não'}</span></div>
+            <div class="detail-row"><span class="detail-label">Imóvel:</span><span class="detail-value">${info.imovel}</span></div>
+            <div class="detail-row"><span class="detail-label">Tipo:</span><span class="detail-value">${info.tipo}</span></div>
+            <div class="detail-row"><span class="detail-label">Arquétipo:</span><span class="detail-value">${info.arquetipo}</span></div>
+        `;
+        document.getElementById('agencyModal').classList.remove('hidden');
     }
 
     openSupplierCommunication(incidentId) {

--- a/app.js
+++ b/app.js
@@ -5,12 +5,20 @@ class IBSApp {
         this.filteredIncidents = [];
         this.currentPage = 1;
         this.itemsPerPage = 15;
+        this.heatRadius = 25;
+
+        const storedPerPage = localStorage.getItem('itemsPerPage');
+        if (storedPerPage) this.itemsPerPage = parseInt(storedPerPage, 10) || 15;
+        const storedRadius = localStorage.getItem('heatRadius');
+        if (storedRadius) this.heatRadius = parseInt(storedRadius, 10) || 25;
         this.charts = {};
+        this.reportCharts = {};
         this.filters = {
             equipment: '',
             severity: '',
             status: '',
-            period: 90
+            period: 90,
+            search: ''
         };
         this.currentIncidentId = null;
         this.comments = {};
@@ -55,6 +63,30 @@ class IBSApp {
             "5002 - Aldeota"
         ];
 
+        this.agenciaCoords = {
+            "1001 - Vila Olímpia": [-23.5955, -46.6874],
+            "1002 - Faria Lima": [-23.5693, -46.7001],
+            "1003 - Paulista": [-23.5617, -46.6559],
+            "1004 - Moema": [-23.6019, -46.6735],
+            "1005 - Itaim Bibi": [-23.5874, -46.674],
+            "1006 - Brooklin": [-23.6221, -46.6971],
+            "1007 - Santo Amaro": [-23.6561, -46.7132],
+            "1008 - Pinheiros": [-23.5687, -46.6959],
+            "1009 - Vila Madalena": [-23.5721, -46.695],
+            "1010 - Perdizes": [-23.5353, -46.6683],
+            "2001 - Copacabana": [-22.9719, -43.1822],
+            "2002 - Ipanema": [-22.9836, -43.2048],
+            "2003 - Leblon": [-22.9832, -43.2237],
+            "2004 - Barra da Tijuca": [-23.0003, -43.3609],
+            "2005 - Tijuca": [-22.9252, -43.2315],
+            "3001 - Savassi BH": [-19.9318, -43.9392],
+            "3002 - Centro BH": [-19.9191, -43.9386],
+            "4001 - Boa Viagem": [-8.1222, -34.9156],
+            "4002 - Casa Forte": [-8.0351, -34.9111],
+            "5001 - Meireles": [-3.7225, -38.4934],
+            "5002 - Aldeota": [-3.7363, -38.4885]
+        };
+
         this.responsaveis = [
             "João Silva - Técnico TI", "Maria Santos - Suporte N2", "Pedro Costa - Especialista ATM",
             "Ana Oliveira - Técnico Redes", "Carlos Lima - Suporte Segurança", "Fernanda Alves - Técnico Hardware",
@@ -71,9 +103,12 @@ class IBSApp {
         ];
 
         this.usuarios = [
-            "Carlos Mendes - Analista NOC", "Fernanda Silva - Supervisora Técnica", 
+            "Carlos Mendes - Analista NOC", "Fernanda Silva - Supervisora Técnica",
             "Roberto Lima - Coordenador Operacional", "Ana Costa - Analista de Suporte"
         ];
+
+        this.maps = {};
+        this.heatLayer = null;
 
         this.init();
     }
@@ -91,6 +126,8 @@ class IBSApp {
         setTimeout(() => {
             this.createCharts();
         }, 100);
+
+        this.setupThemeToggle();
     }
 
     generateMockData() {
@@ -317,6 +354,11 @@ class IBSApp {
             this.applyFilters();
         });
 
+        document.getElementById('searchInput').addEventListener('keyup', (e) => {
+            this.filters.search = e.target.value;
+            this.applyFilters();
+        });
+
         document.getElementById('clearFilters').addEventListener('click', () => {
             this.clearFilters();
         });
@@ -397,6 +439,60 @@ class IBSApp {
         document.getElementById('exportBtn').addEventListener('click', () => {
             this.exportData();
         });
+
+        const ltFilter = document.getElementById('longTailStatusFilter');
+        if (ltFilter) {
+            ltFilter.addEventListener('change', () => {
+                if (this.charts.longTail) this.updateLongTailChart();
+            });
+        }
+
+        const ltFilterReport = document.getElementById('longTailStatusFilterReport');
+        if (ltFilterReport) {
+            ltFilterReport.addEventListener('change', () => {
+                if (this.reportCharts.longTail) this.updateLongTailChartReport();
+            });
+        }
+
+        const mapFilter = document.getElementById('mapStatusFilter');
+        if (mapFilter) {
+            mapFilter.addEventListener('change', () => {
+                if (this.maps.agency) this.updateAgencyMap();
+            });
+        }
+
+        const themeSelect = document.getElementById('defaultTheme');
+        if (themeSelect) {
+            themeSelect.addEventListener('change', (e) => {
+                const value = e.target.value;
+                document.body.dataset.colorScheme = value;
+                localStorage.setItem('theme', value);
+            });
+        }
+
+        const pageInput = document.getElementById('itemsPerPage');
+        if (pageInput) {
+            pageInput.value = this.itemsPerPage;
+            pageInput.addEventListener('change', (e) => {
+                this.itemsPerPage = parseInt(e.target.value, 10) || 15;
+                localStorage.setItem('itemsPerPage', this.itemsPerPage);
+                this.updateTable();
+            });
+        }
+
+        const radiusInput = document.getElementById('heatRadius');
+        if (radiusInput) {
+            radiusInput.value = this.heatRadius;
+            radiusInput.addEventListener('input', (e) => {
+                this.heatRadius = parseInt(e.target.value, 10) || 25;
+                localStorage.setItem('heatRadius', this.heatRadius);
+                if (this.heatLayer && this.maps.agency) {
+                    this.maps.agency.removeLayer(this.heatLayer);
+                    this.heatLayer = null;
+                }
+                if (this.maps.agency) this.updateAgencyMap();
+            });
+        }
     }
 
     setupFilters() {
@@ -437,10 +533,30 @@ class IBSApp {
         if (section === 'incidents') {
             document.getElementById('dashboard-section').style.display = 'none';
             document.getElementById('incidents-section').style.display = 'block';
+            document.getElementById('reports-section').style.display = 'none';
+            document.getElementById('settings-section').style.display = 'none';
             this.updateTable();
+        } else if (section === 'reports') {
+            document.getElementById('dashboard-section').style.display = 'none';
+            document.getElementById('incidents-section').style.display = 'none';
+            document.getElementById('reports-section').style.display = 'block';
+            document.getElementById('settings-section').style.display = 'none';
+            if (!this.maps.agency) {
+                this.createAgencyMap();
+            } else {
+                setTimeout(() => this.maps.agency.invalidateSize(), 100);
+            }
+            this.updateReports();
+        } else if (section === 'settings') {
+            document.getElementById('dashboard-section').style.display = 'none';
+            document.getElementById('incidents-section').style.display = 'none';
+            document.getElementById('reports-section').style.display = 'none';
+            document.getElementById('settings-section').style.display = 'block';
         } else {
             document.getElementById('dashboard-section').style.display = 'block';
             document.getElementById('incidents-section').style.display = 'none';
+            document.getElementById('reports-section').style.display = 'none';
+            document.getElementById('settings-section').style.display = 'none';
         }
     }
 
@@ -465,19 +581,25 @@ class IBSApp {
         const now = new Date();
         const periodStart = new Date(now.getTime() - (this.filters.period * 24 * 60 * 60 * 1000));
 
+        const search = this.filters.search.toLowerCase();
         this.filteredIncidents = this.incidents.filter(incident => {
             const matchesPeriod = incident.startDate >= periodStart;
             const matchesEquipment = !this.filters.equipment || incident.equipment === this.filters.equipment;
             const matchesSeverity = !this.filters.severity || incident.severity === this.filters.severity;
             const matchesStatus = !this.filters.status || incident.status === this.filters.status;
+            const matchesSearch = !search ||
+                incident.id.toLowerCase().includes(search) ||
+                incident.description.toLowerCase().includes(search) ||
+                incident.agency.toLowerCase().includes(search);
 
-            return matchesPeriod && matchesEquipment && matchesSeverity && matchesStatus;
+            return matchesPeriod && matchesEquipment && matchesSeverity && matchesStatus && matchesSearch;
         });
 
         this.currentPage = 1;
         this.updateDashboard();
         this.updateCharts();
         this.updateTable();
+        this.updateReports();
     }
 
     clearFilters() {
@@ -485,13 +607,17 @@ class IBSApp {
             equipment: '',
             severity: '',
             status: '',
-            period: 90
+            period: 90,
+            search: ''
         };
 
         document.getElementById('equipmentFilter').value = '';
         document.getElementById('severityFilter').value = '';
         document.getElementById('statusFilter').value = '';
         document.getElementById('periodFilter').value = '90';
+        document.getElementById('searchInput').value = '';
+        const mapFilter = document.getElementById('mapStatusFilter');
+        if (mapFilter) mapFilter.value = 'abertas';
 
         this.applyFilters();
     }
@@ -519,6 +645,9 @@ class IBSApp {
         document.getElementById('activePercentage').textContent = total > 0 ? `${Math.round((active / total) * 100)}% do total` : '0% do total';
         document.getElementById('averageMTTR').textContent = `${avgMTTR.toFixed(1)}h`;
         document.getElementById('averageMTTD').textContent = `${(avgMTTD * 60).toFixed(0)}min`;
+
+        const summary = `Nos últimos ${this.filters.period} dias foram registradas ${total} ocorrências, ${resolved} resolvidas.`;
+        document.getElementById('summaryText').textContent = summary;
     }
 
     createCharts() {
@@ -526,6 +655,14 @@ class IBSApp {
         this.createEquipmentChart();
         this.createMonthlyTrendChart();
         this.createMTTRChart();
+        this.createLongTailChart();
+        this.createAgencyMap();
+
+        this.createSeverityChartReport();
+        this.createEquipmentChartReport();
+        this.createMonthlyTrendChartReport();
+        this.createMTTRChartReport();
+        this.createLongTailChartReport();
     }
 
     updateCharts() {
@@ -533,6 +670,13 @@ class IBSApp {
         if (this.charts.equipment) this.updateEquipmentChart();
         if (this.charts.monthlyTrend) this.updateMonthlyTrendChart();
         if (this.charts.mttr) this.updateMTTRChart();
+        if (this.charts.longTail) this.updateLongTailChart();
+        if (this.maps.agency) this.updateAgencyMap();
+        if (this.reportCharts.severity) this.updateSeverityChartReport();
+        if (this.reportCharts.equipment) this.updateEquipmentChartReport();
+        if (this.reportCharts.monthlyTrend) this.updateMonthlyTrendChartReport();
+        if (this.reportCharts.mttr) this.updateMTTRChartReport();
+        if (this.reportCharts.longTail) this.updateLongTailChartReport();
     }
 
     createSeverityChart() {
@@ -785,6 +929,286 @@ class IBSApp {
         };
     }
 
+    getLongTailData(view) {
+        const bins = ['<1d', '1-2d', '2-3d', '3-5d', '5-7d', '7-14d', '14+d'];
+        const counts = Array(bins.length).fill(0);
+        const now = new Date();
+        const dataset = this.filteredIncidents.filter(inc => {
+            const closed = inc.status === 'Resolvido' || inc.status === 'Fechado';
+            return view === 'fechadas' ? closed : !closed;
+        });
+
+        dataset.forEach(inc => {
+            const endDate = inc.resolutionDate ? inc.resolutionDate : now;
+            const days = (endDate - inc.startDate) / (1000 * 60 * 60 * 24);
+            let idx = 6;
+            if (days < 1) idx = 0;
+            else if (days < 2) idx = 1;
+            else if (days < 3) idx = 2;
+            else if (days < 5) idx = 3;
+            else if (days < 7) idx = 4;
+            else if (days < 14) idx = 5;
+            counts[idx]++;
+        });
+
+        return { labels: bins, data: counts };
+    }
+
+    createLongTailChart() {
+        const ctx = document.getElementById('longTailChart').getContext('2d');
+        const filter = document.getElementById('longTailStatusFilter').value;
+        const data = this.getLongTailData(filter);
+
+        this.charts.longTail = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: data.labels,
+                datasets: [{
+                    label: 'Ocorrências',
+                    data: data.data,
+                    backgroundColor: '#A855F7',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: { stepSize: 1 }
+                    }
+                }
+            }
+        });
+    }
+
+    updateLongTailChart() {
+        const filter = document.getElementById('longTailStatusFilter').value;
+        const data = this.getLongTailData(filter);
+        this.charts.longTail.data.datasets[0].data = data.data;
+        this.charts.longTail.update();
+    }
+
+    createSeverityChartReport() {
+        const ctx = document.getElementById('severityChartReport').getContext('2d');
+        const severityData = this.getSeverityData();
+        this.reportCharts.severity = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: severityData.labels,
+                datasets: [{
+                    label: 'Incidentes',
+                    data: severityData.data,
+                    backgroundColor: severityData.colors,
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
+            }
+        });
+    }
+
+    updateSeverityChartReport() {
+        const data = this.getSeverityData();
+        this.reportCharts.severity.data.datasets[0].data = data.data;
+        this.reportCharts.severity.update();
+    }
+
+    createEquipmentChartReport() {
+        const ctx = document.getElementById('equipmentChartReport').getContext('2d');
+        const equipmentData = this.getEquipmentData();
+        this.reportCharts.equipment = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: equipmentData.labels,
+                datasets: [{
+                    label: 'Incidentes',
+                    data: equipmentData.data,
+                    backgroundColor: '#1FB8CD',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: { beginAtZero: true, ticks: { stepSize: 1 } },
+                    x: { ticks: { maxRotation: 45 } }
+                }
+            }
+        });
+    }
+
+    updateEquipmentChartReport() {
+        const data = this.getEquipmentData();
+        this.reportCharts.equipment.data.datasets[0].data = data.data;
+        this.reportCharts.equipment.update();
+    }
+
+    createMonthlyTrendChartReport() {
+        const ctx = document.getElementById('monthlyTrendChartReport').getContext('2d');
+        const monthlyData = this.getMonthlyData();
+        this.reportCharts.monthlyTrend = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: monthlyData.labels,
+                datasets: [{
+                    label: 'Incidentes por Mês',
+                    data: monthlyData.data,
+                    borderColor: '#1FB8CD',
+                    backgroundColor: 'rgba(31, 184, 205, 0.1)',
+                    fill: true,
+                    tension: 0.4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
+            }
+        });
+    }
+
+    updateMonthlyTrendChartReport() {
+        const data = this.getMonthlyData();
+        this.reportCharts.monthlyTrend.data.datasets[0].data = data.data;
+        this.reportCharts.monthlyTrend.update();
+    }
+
+    createMTTRChartReport() {
+        const ctx = document.getElementById('mttrChartReport').getContext('2d');
+        const mttrData = this.getMTTRData();
+        this.reportCharts.mttr = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: mttrData.labels,
+                datasets: [{
+                    label: 'MTTR Médio (horas)',
+                    data: mttrData.data,
+                    borderColor: '#FFC185',
+                    backgroundColor: 'rgba(255, 193, 133, 0.1)',
+                    fill: true,
+                    tension: 0.4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: { callback: value => value + 'h' }
+                    }
+                }
+            }
+        });
+    }
+
+    updateMTTRChartReport() {
+        const data = this.getMTTRData();
+        this.reportCharts.mttr.data.datasets[0].data = data.data;
+        this.reportCharts.mttr.update();
+    }
+
+    createLongTailChartReport() {
+        const ctx = document.getElementById('longTailChartReport').getContext('2d');
+        const filter = document.getElementById('longTailStatusFilterReport').value;
+        const data = this.getLongTailData(filter);
+        this.reportCharts.longTail = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: data.labels,
+                datasets: [{
+                    label: 'Ocorrências',
+                    data: data.data,
+                    backgroundColor: '#A855F7',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
+            }
+        });
+    }
+
+    updateLongTailChartReport() {
+        const filter = document.getElementById('longTailStatusFilterReport').value;
+        const data = this.getLongTailData(filter);
+        this.reportCharts.longTail.data.datasets[0].data = data.data;
+        this.reportCharts.longTail.update();
+    }
+
+    createAgencyMap() {
+        const map = L.map('agencyMap').setView([-15.78, -47.93], 4);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18,
+            attribution: '© OpenStreetMap'
+        }).addTo(map);
+        this.maps.agency = map;
+        this.updateAgencyMap();
+    }
+
+    getAgencyHeatData(view) {
+        const counts = {};
+        const dataset = this.filteredIncidents.filter(inc => {
+            const closed = inc.status === 'Resolvido' || inc.status === 'Fechado';
+            return view === 'abertas' ? !closed : true;
+        });
+
+        dataset.forEach(inc => {
+            const coords = this.agenciaCoords[inc.agency];
+            if (coords) {
+                const key = coords.join(',');
+                counts[key] = (counts[key] || 0) + 1;
+            }
+        });
+
+        return Object.entries(counts).map(([k, c]) => {
+            const [lat, lng] = k.split(',').map(Number);
+            return [lat, lng, c];
+        });
+    }
+
+    updateAgencyMap() {
+        const filter = document.getElementById('mapStatusFilter').value;
+        const heatData = this.getAgencyHeatData(filter);
+        if (this.heatLayer) {
+            this.heatLayer.setLatLngs(heatData);
+        } else if (this.maps.agency) {
+            this.heatLayer = L.heatLayer(heatData, { radius: this.heatRadius }).addTo(this.maps.agency);
+        }
+    }
+
+    updateReports() {
+        if (this.maps.agency) this.updateAgencyMap();
+        const agencies = new Set(this.filteredIncidents.map(inc => inc.agency));
+        const total = this.filteredIncidents.length;
+        const resolved = this.filteredIncidents.filter(inc => inc.status === 'Resolvido' || inc.status === 'Fechado');
+        const open = total - resolved.length;
+        const severityCounts = {};
+        this.filteredIncidents.forEach(inc => {
+            severityCounts[inc.severity] = (severityCounts[inc.severity] || 0) + 1;
+        });
+        const topSeverity = Object.entries(severityCounts).sort((a, b) => b[1] - a[1])[0];
+        const topSeverityName = topSeverity ? topSeverity[0] : '';
+        const avgMttr = resolved.length > 0 ?
+            resolved.reduce((sum, inc) => sum + ((inc.resolutionDate - inc.startDate) / 3600000), 0) / resolved.length : 0;
+
+        const text = `Nos últimos ${this.filters.period} dias monitoramos ${agencies.size} agências e registramos ${total} ocorrências, ` +
+            `${open} em aberto. A severidade mais comum foi ${topSeverityName} ` +
+            `e o MTTR médio das ocorrências resolvidas está em ${avgMttr.toFixed(1)} horas.`;
+        const el = document.getElementById('reportsNarrative');
+        if (el) el.textContent = text;
+    }
+
     updateTable() {
         const tableBody = document.getElementById('incidentsTableBody');
         tableBody.innerHTML = '';
@@ -976,6 +1400,8 @@ class IBSApp {
             </div>
         `;
 
+        this.renderTimeline(incidentId);
+
         // Reset to details tab
         this.switchTab('details');
         document.getElementById('incidentModal').classList.remove('hidden');
@@ -1094,11 +1520,39 @@ class IBSApp {
                     </span>
                 </div>
                 <div class="communication-meta">
-                    <strong>Para:</strong> ${comm.supplier} • 
-                    <strong>Prioridade:</strong> ${comm.priority.charAt(0).toUpperCase() + comm.priority.slice(1)} • 
+                    <strong>Para:</strong> ${comm.supplier} •
+                    <strong>Prioridade:</strong> ${comm.priority.charAt(0).toUpperCase() + comm.priority.slice(1)} •
                     ${comm.timestamp.toLocaleDateString('pt-BR')} ${comm.timestamp.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
                 </div>
                 <div class="communication-text">${comm.message}</div>
+            </div>
+        `).join('');
+    }
+
+    renderTimeline(incidentId) {
+        const container = document.getElementById('timelineContainer');
+        if (!container) return;
+        const incident = this.incidents.find(inc => inc.id === incidentId);
+        if (!incident) return;
+
+        const events = [];
+        events.push({ time: incident.startDate, text: 'Incidente aberto' });
+        (this.comments[incidentId] || []).forEach(c => {
+            events.push({ time: c.timestamp, text: `Comentário: ${c.text}` });
+        });
+        (this.communications[incidentId] || []).forEach(c => {
+            events.push({ time: c.timestamp, text: `Comunicação: ${c.subject}` });
+        });
+        if (incident.resolutionDate) {
+            events.push({ time: incident.resolutionDate, text: 'Incidente resolvido' });
+        }
+
+        events.sort((a, b) => a.time - b.time);
+
+        container.innerHTML = events.map(ev => `
+            <div class="timeline-item">
+                <div class="timeline-date">${ev.time.toLocaleDateString('pt-BR')} ${ev.time.toLocaleTimeString('pt-BR')}</div>
+                <div class="timeline-text">${ev.text}</div>
             </div>
         `).join('');
     }
@@ -1252,17 +1706,46 @@ class IBSApp {
         }, 300);
     }
 
+    setupThemeToggle() {
+        const body = document.body;
+        const saved = localStorage.getItem('theme');
+        if (saved) {
+            body.dataset.colorScheme = saved;
+        }
+        const btn = document.getElementById('themeToggle');
+        if (btn) {
+            btn.addEventListener('click', () => {
+                const next = body.dataset.colorScheme === 'dark' ? 'light' : 'dark';
+                body.dataset.colorScheme = next;
+                localStorage.setItem('theme', next);
+            });
+        }
+    }
+
     exportData() {
-        const csvContent = this.generateCSV();
-        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-        const link = document.createElement('a');
-        const url = URL.createObjectURL(blob);
-        link.setAttribute('href', url);
-        link.setAttribute('download', `incidentes_itau_${new Date().toISOString().split('T')[0]}.csv`);
-        link.style.visibility = 'hidden';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        const btn = document.getElementById('exportBtn');
+        if (btn) {
+            btn.classList.add('loading');
+            btn.textContent = 'Exportando...';
+        }
+
+        setTimeout(() => {
+            const csvContent = this.generateCSV();
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const link = document.createElement('a');
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', `incidentes_itau_${new Date().toISOString().split('T')[0]}.csv`);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+            if (btn) {
+                btn.classList.remove('loading');
+                btn.textContent = 'Exportar Relatório';
+            }
+        }, 500);
     }
 
     generateCSV() {

--- a/index.html
+++ b/index.html
@@ -321,6 +321,19 @@
         </main>
     </div>
 
+    <!-- Agency Info Modal -->
+    <div id="agencyModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Informações da Agência</h3>
+                <button class="modal-close" id="closeAgencyModal" aria-label="Fechar">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div id="agencyModalBody"></div>
+            </div>
+        </div>
+    </div>
+
     <!-- Incident Detail Modal -->
     <div id="incidentModal" class="modal hidden">
         <div class="modal-content modal-content--large">

--- a/index.html
+++ b/index.html
@@ -5,20 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>IBS 360 - Sistema de Gestão de Ocorrências | Itaú</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js"></script>
 </head>
 <body data-color-scheme="dark">
     <!-- Header -->
     <header class="header">
         <div class="header-content">
             <div class="header-left">
-                <div class="logo">
-                    <span class="logo-icon">🏦</span>
+                <div class="logo" aria-label="Itaú">
+                    <span class="logo-icon" aria-hidden="true">🏦</span>
                     <span class="logo-text">Ferramenta de Acompanhamento - COPF</span>
                 </div>
             </div>
             <div class="header-right">
                 <span class="user-info">Sistema Itaú - Gestão de Ocorrências</span>
+                <button id="themeToggle" class="btn btn--secondary" aria-label="Alternar tema">🌓</button>
             </div>
         </div>
     </header>
@@ -29,26 +33,26 @@
             <nav class="sidebar-nav">
                 <ul class="nav-list">
                     <li class="nav-item active">
-                        <a href="#" class="nav-link" data-section="dashboard">
-                            <span class="nav-icon">📊</span>
+                        <a href="#" class="nav-link" data-section="dashboard" aria-label="Dashboard">
+                            <span class="nav-icon" aria-hidden="true">📊</span>
                             <span class="nav-text">Dashboard</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="incidents">
-                            <span class="nav-icon">⚠️</span>
+                        <a href="#" class="nav-link" data-section="incidents" aria-label="Ocorrências">
+                            <span class="nav-icon" aria-hidden="true">⚠️</span>
                             <span class="nav-text">Ocorrências</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="reports">
-                            <span class="nav-icon">📈</span>
+                        <a href="#" class="nav-link" data-section="reports" aria-label="Relatórios">
+                            <span class="nav-icon" aria-hidden="true">📈</span>
                             <span class="nav-text">Relatórios</span>
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="#" class="nav-link" data-section="settings">
-                            <span class="nav-icon">⚙️</span>
+                        <a href="#" class="nav-link" data-section="settings" aria-label="Configurações">
+                            <span class="nav-icon" aria-hidden="true">⚙️</span>
                             <span class="nav-text">Configurações</span>
                         </a>
                     </li>
@@ -86,6 +90,10 @@
                             <option value="60">Últimos 60 dias</option>
                             <option value="90" selected>Últimos 90 dias</option>
                         </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="searchInput" class="form-label">Busca Rápida:</label>
+                        <input id="searchInput" type="text" class="form-control" placeholder="Buscar por texto ou ID">
                     </div>
                     <div class="filter-group">
                         <button id="clearFilters" class="btn btn--secondary">Limpar Filtros</button>
@@ -139,6 +147,8 @@
                     </div>
                 </div>
 
+                <p id="summaryText" class="summary-text"></p>
+
                 <!-- Charts Grid -->
                 <div class="charts-grid">
                     <div class="chart-container">
@@ -171,6 +181,18 @@
                         </div>
                         <div class="chart-content">
                             <canvas id="mttrChart"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container chart-wide">
+                        <div class="chart-header">
+                            <h3 class="chart-title">Long Tail de Ocorrências</h3>
+                            <select id="longTailStatusFilter" class="form-control">
+                                <option value="abertas">Em Aberto</option>
+                                <option value="fechadas">Fechadas</option>
+                            </select>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="longTailChart"></canvas>
                         </div>
                     </div>
                 </div>
@@ -214,6 +236,88 @@
                     </div>
                 </div>
             </section>
+
+            <!-- Reports Section -->
+            <section id="reports-section" class="reports-section" style="display:none;">
+                <h2 class="section-title">Relatórios</h2>
+                <p id="reportsNarrative" class="summary-text"></p>
+                <div class="chart-container chart-wide">
+                    <div class="chart-header">
+                        <h3 class="chart-title">Mapa de Agências</h3>
+                        <select id="mapStatusFilter" class="form-control">
+                            <option value="abertas">Abertas</option>
+                            <option value="todas">Todas</option>
+                        </select>
+                    </div>
+                    <div id="agencyMap" class="map-container"></div>
+                </div>
+                <div class="charts-grid">
+                    <div class="chart-container">
+                        <div class="chart-header">
+                            <h3 class="chart-title">Ocorrências por Severidade</h3>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="severityChartReport"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container">
+                        <div class="chart-header">
+                            <h3 class="chart-title">Ocorrências por Equipamento</h3>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="equipmentChartReport"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container chart-wide">
+                        <div class="chart-header">
+                            <h3 class="chart-title">Tendência Mensal de Ocorrências</h3>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="monthlyTrendChartReport"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container chart-wide">
+                        <div class="chart-header">
+                            <h3 class="chart-title">MTTR Mensal</h3>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="mttrChartReport"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container chart-wide">
+                        <div class="chart-header">
+                            <h3 class="chart-title">Long Tail de Ocorrências</h3>
+                            <select id="longTailStatusFilterReport" class="form-control">
+                                <option value="abertas">Em Aberto</option>
+                                <option value="fechadas">Fechadas</option>
+                            </select>
+                        </div>
+                        <div class="chart-content">
+                            <canvas id="longTailChartReport"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Settings Section -->
+            <section id="settings-section" class="settings-section" style="display:none;">
+                <h2 class="section-title">Configurações</h2>
+                <div class="form-group">
+                    <label for="defaultTheme" class="form-label">Tema Padrão:</label>
+                    <select id="defaultTheme" class="form-control">
+                        <option value="light">Claro</option>
+                        <option value="dark">Escuro</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="itemsPerPage" class="form-label">Itens por Página:</label>
+                    <input type="number" id="itemsPerPage" class="form-control" min="5" max="50" step="5" value="15">
+                </div>
+                <div class="form-group">
+                    <label for="heatRadius" class="form-label">Intensidade do Heatmap:</label>
+                    <input type="range" id="heatRadius" min="10" max="50" step="5" value="25">
+                </div>
+            </section>
         </main>
     </div>
 
@@ -222,7 +326,7 @@
         <div class="modal-content modal-content--large">
             <div class="modal-header">
                 <h3 class="modal-title">Detalhes do Incidente</h3>
-                <button class="modal-close" id="closeModal">&times;</button>
+                <button class="modal-close" id="closeModal" aria-label="Fechar">&times;</button>
             </div>
             <div class="modal-tabs">
                 <button class="tab-button active" data-tab="details">Detalhes</button>
@@ -232,6 +336,7 @@
             <div class="modal-body">
                 <div class="tab-content active" id="tab-details">
                     <div id="modalBody"></div>
+                    <div id="timelineContainer" class="timeline-list"></div>
                 </div>
                 <div class="tab-content" id="tab-comments">
                     <div class="comments-section">
@@ -250,7 +355,7 @@
                             </div>
                             <div class="comment-actions">
                                 <button class="btn btn--secondary" id="saveComment">Salvar Comentário</button>
-                                <button class="btn btn--primary" id="sendToSupplier">Enviar para Fornecedor</button>
+                                <button class="btn btn--primary" id="sendToSupplier" aria-label="Enviar para Fornecedor">Enviar para Fornecedor</button>
                             </div>
                         </div>
                         <div class="comments-history">
@@ -262,7 +367,7 @@
                 <div class="tab-content" id="tab-communications">
                     <div class="communications-section">
                         <div class="communication-actions">
-                            <button class="btn btn--primary" id="newCommunication">📤 Nova Comunicação</button>
+                            <button class="btn btn--primary" id="newCommunication" aria-label="Nova Comunicação">📤 Nova Comunicação</button>
                         </div>
                         <div class="communications-history">
                             <h4>Histórico de Comunicações</h4>
@@ -279,7 +384,7 @@
         <div class="modal-content modal-content--large">
             <div class="modal-header">
                 <h3 class="modal-title">💬 Comunicação com Fornecedor</h3>
-                <button class="modal-close" id="closeSupplierModal">&times;</button>
+                <button class="modal-close" id="closeSupplierModal" aria-label="Fechar">&times;</button>
             </div>
             <div class="modal-body">
                 <div class="supplier-form">
@@ -342,7 +447,7 @@
 
                     <div class="supplier-actions">
                         <button class="btn btn--secondary" id="cancelCommunication">Cancelar</button>
-                        <button class="btn btn--primary" id="sendCommunication">📤 Enviar para Fornecedor</button>
+                        <button class="btn btn--primary" id="sendCommunication" aria-label="Enviar para Fornecedor">📤 Enviar para Fornecedor</button>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -1546,6 +1546,15 @@ select.form-control {
 
 .chart-header {
   margin-bottom: var(--space-16);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chart-header .form-control {
+  width: auto;
+  margin-left: var(--space-12);
+  min-width: 140px;
 }
 
 .chart-title {
@@ -2362,4 +2371,54 @@ select.form-control {
   width: 20px;
   background: linear-gradient(to left, var(--color-surface), transparent);
   pointer-events: none;
+}
+
+/* Summary text below KPIs */
+.summary-text {
+  margin: var(--space-16) 0;
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+}
+
+/* Simple timeline */
+.timeline-list {
+  margin-top: var(--space-16);
+  padding-left: var(--space-16);
+  border-left: 2px solid var(--color-border);
+}
+
+.timeline-item {
+  margin-bottom: var(--space-12);
+  position: relative;
+}
+
+.timeline-item::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  position: absolute;
+  left: -5px;
+  top: 4px;
+}
+
+.timeline-date {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+/* Reports */
+.reports-section {
+  display: none;
+}
+
+.map-container {
+  width: 100%;
+  height: 400px;
+}
+
+.settings-section {
+  display: none;
+  margin-bottom: var(--space-32);
 }

--- a/style.css
+++ b/style.css
@@ -1919,6 +1919,16 @@ select.form-control {
   background: #d97706;
 }
 
+.agency-link {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+  padding: 0;
+}
+
 .table-actions {
   display: flex;
   gap: var(--space-8);
@@ -2356,7 +2366,8 @@ select.form-control {
 
 /* Better visibility for action buttons */
 .incidents-table .btn-view,
-.incidents-table .btn-communicate {
+.incidents-table .btn-communicate,
+.incidents-table .agency-link {
   min-width: 80px;
   font-weight: var(--font-weight-medium);
 }


### PR DESCRIPTION
## Summary
- add open/closed long tail filter and heatmap in reports page
- duplicate dashboard charts for use in reports section
- create settings section with theme preference selector
- ensure map resizes correctly when reports tab is shown
- add storytelling narrative to reports page and extra settings for items per page and heatmap intensity

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6867f755ee7c83289fd9176a05d64e69